### PR TITLE
Set __version__ attribute from installation metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,8 +5,9 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/rpanderson/workflow-sandbox
 project_urls = 
-  Source Code=https://github.com/rpanderson/workflow-sandbox
-  Download=https://github.com/rpanderson/workflow-sandbox/releases
+    Source Code=https://github.com/rpanderson/workflow-sandbox
+    Download=https://github.com/rpanderson/workflow-sandbox/releases
+    Tracker=https://github.com/rpanderson/workflow-sandbox/issues
 keywords = example workflow
 license = BSD 3-Clause License
 classifiers =
@@ -26,7 +27,7 @@ packages = find:
 python_requires = >=3.6
 install_requires =
   importlib_metadata>=1.0 ; python_version < '3.8'
-  pywin32 ; sys_platform == 'win32'
+  pywin32>=227 ; sys_platform == 'win32'
   setuptools
 setup_requires =
   setuptools_scm
@@ -40,3 +41,8 @@ docs =
   Sphinx==3.0.1
   sphinx-rtd-theme==0.4.3
   recommonmark==0.6.0
+testing = 
+  pytest
+
+[tool:pytest]
+testpaths = tests

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,11 @@
+from pkg_resources import get_distribution
+import workflow_sandbox
+
+
+def test_version():
+    """Check version against `pkg_resources` from `setuptools`.
+    """
+    assert (
+        workflow_sandbox.__version__
+        == get_distribution('workflow_sandbox').version
+    )

--- a/workflow_sandbox/__init__.py
+++ b/workflow_sandbox/__init__.py
@@ -1,0 +1,15 @@
+# Get the version at runtime from PEP-0566 metadata using `importlib.metadata`
+# from the standard library or the `importlib_metadata` backport
+
+try:
+    # Standard library in Python 3.8+
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # The backport of the Python 3.8 stdlib module
+    import importlib_metadata
+
+try:
+    __version__ = importlib_metadata.version(__name__)
+except importlib_metadata.PackageNotFoundError:
+    # package is not installed
+    pass


### PR DESCRIPTION
Per [`setuptools_scm` docs](https://pypi.org/project/setuptools-scm/#retrieving-package-version-at-runtime):

> If you have opted not to hardcode the version number inside the package, you can retrieve it at runtime from [PEP-0566](https://www.python.org/dev/peps/pep-0566/) metadata using `importlib.metadata` from the standard library or the [importlib_metadata](https://pypi.org/project/importlib-metadata/) backport:

Added a perfunctory test to check this attribute against `pkg_resources.get_distribution`.

This is not robust against working on editable installations, which is nicely addressed by labscript-suite/labscript_utils#32, but I don't want to include a runtime dependency on `setuptools_scm` just yet, or the vendored code from this PR.