### PR TITLE
Omit local version info for non-release (untagged) uploads to TestPyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     env:
-      version: ${ ${{ github.ref }}//v}
+      version: ${${{ github.ref }}//v}
     if: github.repository == 'rpanderson/workflow-sandbox'
     steps:
       - name: Checkout
@@ -22,6 +22,7 @@ jobs:
           python-version: 3.8
       - name: Build Distribution
         run: |
+          touch no-local-version
           python -m pip install --upgrade pip setuptools wheel
           python setup.py sdist bdist_wheel
       - name: Publish on TestPyPI

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,9 @@
 from setuptools import setup
+from pathlib import Path
 
-setup(use_scm_version=True)
+if Path("no-local-version").exists():
+    VERSION_SCHEME = {"local_scheme": "no-local-version"}
+else:
+    VERSION_SCHEME = True
+
+setup(use_scm_version=VERSION_SCHEME)


### PR DESCRIPTION
The latest `.github/workflows/releases.yml`:
- Builds _every_ push to `master` or `release*` branches;
- Uploads these to TestPyPI; and
- Only those with a `v`-prefixed tag trigger a GitHub Release and upload to PyPI,

However, by default, `setuptools_scm` appends a local version to untagged commits, e.g. `0.1.0rc4dev3+g9e08dc6`,  
```
HTTPError: 400 Client Error: '0.1.0rc4dev3+g9e08dc6' is an invalid value for Version. Error: Can't use PEP 440 local versions.
```
The way to get around this is to use the [`no-local-version` scheme](https://pypi.org/project/setuptools-scm/#version-number-construction), i.e.
```python
setup(use_scm_version={"local_scheme": "no-local-version"})
```
This PR dispenses with the local version number if a `no-local-version` file is present at build. Thus, the build action can use `touch no-local-version` to strip the local version for a TestPyPI compatible development build, e.g. `0.1.0rc4dev3`.