### PR TITLE
Use environment variables for setuptools_scm version schemes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     env:
-      version: ${${{ github.ref }}//v}
+      VERSION: ${${{ github.ref }}//v}
     if: github.repository == 'rpanderson/workflow-sandbox'
     steps:
       - name: Checkout
@@ -21,8 +21,9 @@ jobs:
         with:
           python-version: 3.8
       - name: Build Distribution
+        env:
+          SCM_LOCAL_VERSION: no-local-version
         run: |
-          touch no-local-version
           python -m pip install --upgrade pip setuptools wheel
           python setup.py sdist bdist_wheel
       - name: Publish on TestPyPI
@@ -40,7 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: ${{ env.version }}
+          release_name: ${{ env.VERSION }}
           draft: true
           prerelease: ${{ contains(github.ref, 'rc') }}
       - name: Upload Release Asset
@@ -50,8 +51,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./dist/workflow-sandbox-${{ env.version }}.tar.gz
-          asset_name: workflow-sandbox-${{ env.version }}.tar.gz
+          asset_path: ./dist/workflow-sandbox-${{ env.VERSION }}.tar.gz
+          asset_name: workflow-sandbox-${{ env.VERSION }}.tar.gz
           asset_content_type: application/gzip
       - name: Publish on PyPI
         if: startsWith(github.event.ref, 'refs/tags') && startsWith(github.ref, 'v')

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,12 @@
+import os
 from setuptools import setup
-from pathlib import Path
 
-if Path("no-local-version").exists():
-    VERSION_SCHEME = {"local_scheme": "no-local-version"}
-else:
-    VERSION_SCHEME = True
+VERSION_SCHEME = {}
+VERSION_SCHEME["version_scheme"] = os.environ.get(
+    "SCM_VERSION_SCHEME", "guess-next-dev"
+)
+VERSION_SCHEME["local_scheme"] = os.environ.get(
+    "SCM_LOCAL_SCHEME", "node-and-date"
+)
 
 setup(use_scm_version=VERSION_SCHEME)


### PR DESCRIPTION
This PR amends #5, by using environment variables `SCM_VERSION_SCHEME` and `SCM_LOCAL_SCHEME` to set `setuptools_scm.version_scheme` and `setuptools_scm.local_scheme`, respectively. The [default scheme](https://github.com/pypa/setuptools_scm#version-number-construction) if either environment variable is absent.

This can be tested by setting either of these environment variables to something other than the default scheme and running `python setup.py --version`. For example:
```
$ echo $SCM_VERSION_SCHEME

$ echo $SCM_LOCAL_SCHEME

$ python setup.py --version
0.1.0rc4.dev5+gcfe4fa1.d20200504
$ export SCM_LOCAL_SCHEME=no-local-version
$ python setup.py --version
0.1.0rc4.dev5
$ export SCM_VERSION_SCHEME=post-release
$ python setup.py --version
0.1.0rc3.post6
```