### PR TITLE
Only upload to PyPI upon tag creation or pushing development builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python setup.py sdist bdist_wheel
+          SCM_VERSION=$(python setup.py --version)
+          echo "::set-env name=SCM_VERSION::$SCM_VERSION"
       - name: Publish on TestPyPI
+        if: github.event.ref_type == 'tag' || contains(env.SCM_VERSION, 'dev')
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__


### PR DESCRIPTION
... but not both as this triggers a duplicate upload. Resolves #10.

I've used a inter-step environment variable. If created at the job level, these can use [GitHub Actions syntax](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#env)
```
env:
  SCM_VERSION: ...
```
But since the environment variable must be created during a step within the job, the more clunky export method must be used:
```
run:
  ...
  SCM_VERSION=$(python setup.py --version)
  echo "::set-env name=SCM_VERSION::$SCM_VERSION"
```
which is later referenced in other steps via `env.SCM_VERSION`.

See:
- Edward Thompson's [GitHub Actions Day 15: Sharing Data Between Steps](https://www.edwardthomson.com/blog/github_actions_15_sharing_data_between_steps.html)