### PR TITLE
Use commit of setuptools_scm where release-branch-semver-scheme was merged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           SCM_LOCAL_SCHEME: no-local-version
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          pip install -U git+https://github.com/chrisjbillington/setuptools_scm.git@release-branch-semver-scheme
+          pip install -U git+https://github.com/pypa/setuptools_scm.git@8e6aa2b5fd42cb257c86e6dbe720eaee6d1e2c9b
           python setup.py sdist bdist_wheel
           SCM_VERSION=$(python setup.py --version)
           echo "::set-env name=SCM_VERSION::$SCM_VERSION"


### PR DESCRIPTION
The release-branch-semver-scheme branch of my fork of setuptools_scm is gone, since it was merged into the main project.

Point pip at the merge commit where it was merged instead.