### PR TITLE
Different prevention of duplicate test PyPI uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 
+defaults:
+  run:
+    shell: bash
+    
 jobs:
   github_properties:
     name: GitHub Properties
@@ -37,6 +41,7 @@ jobs:
         if: github.event.ref_type != 'tag'
         run: |
           git fetch --prune --unshallow
+          git tag -d $(git tag --points-at HEAD)
           git describe --tags
           git log -1
       - name: Install Python
@@ -53,7 +58,6 @@ jobs:
           SCM_VERSION=$(python setup.py --version)
           echo "::set-env name=SCM_VERSION::$SCM_VERSION"
       - name: Publish on TestPyPI
-        if: github.event.ref_type == 'tag' || contains(env.SCM_VERSION, 'dev')
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__


### PR DESCRIPTION
If not triggered by a tag-create event, delete all tags pointing to the
current commit so that it is always treated as a development version.

This prevents a race condition where a commit tagged soon after being
pushed may either end on on test PyPI as a .dev version *and* a
release, or only the latter, depending on timing. If there is a matrix
of jobs running, which of these happens could be different for each job,
leading to some platforms having an extra dev version on test PyPI that
others platforms don't.

This makes it deterministic: unless we're in a tag event, don't use any
tags from the current commit, and determine the version from previous
tags only.

And we can get rid of the if statement that was designed to prevent
duplicate PyPI uploads.

Relevant: #10, #13