### PR TITLE
Dev dependent version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest]
-        python: ['3.8', '3.7', '3.6']
-        architecture: ['x64', 'x86']
-        include:
-          - os: ubuntu-latest
-            python: '3.x'
-            architecture: 'x64'
+        os: [ubuntu-latest]
+        python: ['3.x']
+        architecture: ['x64']
     env:
       SCM_VERSION_SCHEME: release-branch-semver
       SCM_LOCAL_SCHEME: no-local-version

--- a/workflow_sandbox/__init__.py
+++ b/workflow_sandbox/__init__.py
@@ -1,15 +1,1 @@
-# Get the version at runtime from PEP-0566 metadata using `importlib.metadata`
-# from the standard library or the `importlib_metadata` backport
-
-try:
-    # Standard library in Python 3.8+
-    import importlib.metadata as importlib_metadata
-except ImportError:
-    # The backport of the Python 3.8 stdlib module
-    import importlib_metadata
-
-try:
-    __version__ = importlib_metadata.version(__name__)
-except importlib_metadata.PackageNotFoundError:
-    # package is not installed
-    pass
+from .__version__ import __version__  # noqa: F401

--- a/workflow_sandbox/__version__.py
+++ b/workflow_sandbox/__version__.py
@@ -1,0 +1,28 @@
+import os
+from pathlib import Path
+
+try:
+    # Standard library in Python 3.8+
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # The backport of the Python 3.8 stdlib module
+    import importlib_metadata
+
+VERSION_SCHEME = {
+    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "guess-next-dev"),
+    "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
+}
+
+root = Path(__file__).parent.parent
+if (root / '.git').is_dir():
+    # Use setuptools_scm when in a git repository
+    from setuptools_scm import get_version
+
+    __version__ = get_version(root, **VERSION_SCHEME)
+else:
+    # Get the version at runtime from PEP-0566 metadata using `importlib.metadata`
+    # from the standard library or the `importlib_metadata` backport
+    try:
+        __version__ = importlib_metadata.version(__package__)
+    except importlib_metadata.PackageNotFoundError:
+        __version__ = None


### PR DESCRIPTION
Introspect version attribute from `setuptools_scm` when running from a git repo, and move version introspection to __version__.py