### PR TITLE
Build impure Python packages and conda packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
           source .miniconda/etc/profile.d/conda.sh
           conda activate
           conda create -n py${{ matrix.python }} python=${{ matrix.python }}
-        
+
       - name: Build Conda Package
         run: |
           source .miniconda/etc/profile.d/conda.sh
@@ -252,7 +252,7 @@ jobs:
             --user $ANACONDA_USER \
             --label test \
             conda_packages/*/*
-              
+
       - name: Publish to Anaconda main label
         if: github.event.ref_type == 'tag'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build and Release
 on:
   push:
     branches:
-      - impure-and-conda
+      - master
       - maintenance/*
   create:
     tags:
@@ -190,12 +190,12 @@ jobs:
           name: conda_packages
           path: ./conda_packages
 
-      # - name: Publish on TestPyPI
-      #   uses: pypa/gh-action-pypi-publish@master
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.testpypi }}
-      #     repository_url: https://test.pypi.org/legacy/
+      - name: Publish on TestPyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.testpypi }}
+          repository_url: https://test.pypi.org/legacy/
 
       - name: Get Version Number
         if: github.event.ref_type == 'tag'
@@ -241,17 +241,17 @@ jobs:
           conda activate
           conda install anaconda-client
 
-      # - name: Publish to Anaconda test label
-      #   if: github.event.ref_type != 'tag'
-      #   run: |
-      #     source .miniconda/etc/profile.d/conda.sh
-      #     conda activate
-      #     anaconda \
-      #       --token ${{ secrets.ANACONDA_API_TOKEN }} \
-      #       upload \
-      #       --user $ANACONDA_USER \
-      #       --label test \
-      #       conda_packages/*/*
+      - name: Publish to Anaconda test label
+        if: github.event.ref_type != 'tag'
+        run: |
+          source .miniconda/etc/profile.d/conda.sh
+          conda activate
+          anaconda \
+            --token ${{ secrets.ANACONDA_API_TOKEN }} \
+            upload \
+            --user $ANACONDA_USER \
+            --label test \
+            conda_packages/*/*
               
       - name: Publish to Anaconda main label
         if: github.event.ref_type == 'tag'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,9 @@
 name: Build and Release
-env:
-  PACKAGE_NAME: workflow-sandbox
+
 on:
   push:
     branches:
-      - master
+      - impure-and-conda
       - maintenance/*
   create:
     tags:
@@ -14,69 +13,196 @@ defaults:
   run:
     shell: bash
 
+env:
+  PACKAGE_NAME: workflow-sandbox
+  SCM_VERSION_SCHEME: release-branch-semver
+  SCM_LOCAL_SCHEME: no-local-version
+  ANACONDA_USER: rpanderson
+
+  # Configuration for a package with compiled extensions:
+  # PURE: false
+  # NOARCH: false
+
+  # Configuration for a package with no extensions, but with dependencies that differ by
+  # platform or Python version:
+  PURE: true
+  NOARCH: false
+
+  # Configuration for a package with no extensions and the same dependencies on all
+  # platforms and Python versions. For this configuration you should comment out all but
+  # the first entry in the job matrix of the build job since multiple platforms are not
+  # needed.
+  # PURE: true
+  # NOARCH: true
+
 jobs:
   build:
     name: Build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        python: ['3.x']
-        architecture: ['x64']
-    env:
-      SCM_VERSION_SCHEME: release-branch-semver
-      SCM_LOCAL_SCHEME: no-local-version
+        include:
+          - { os: ubuntu-latest,   python: 3.8,  arch: x64, conda_fromwheel: false }
+          - { os: ubuntu-latest,   python: 3.7,  arch: x64, conda_fromwheel: false }
+          - { os: ubuntu-latest,   python: 3.6,  arch: x64, conda_fromwheel: false }
+
+          - { os: macos-latest,    python: 3.8,  arch: x64, conda_fromwheel: false }
+          - { os: macos-latest,    python: 3.7,  arch: x64, conda_fromwheel: false }
+          - { os: macos-latest,    python: 3.6,  arch: x64, conda_fromwheel: false }
+
+          - { os: windows-latest,  python: 3.8,  arch: x64, conda_fromwheel: true  }
+          - { os: windows-latest,  python: 3.7,  arch: x64, conda_fromwheel: true  }
+          - { os: windows-latest,  python: 3.6,  arch: x64, conda_fromwheel: true  }
+
+          - { os: windows-latest,  python: 3.8,  arch: x86, conda_fromwheel: true  }
+          - { os: windows-latest,  python: 3.7,  arch: x86, conda_fromwheel: true  }
+          - { os: windows-latest,  python: 3.6,  arch: x86, conda_fromwheel: true  }
+
     if: github.repository == 'rpanderson/workflow-sandbox' && (github.event_name != 'create' || github.event.ref_type != 'branch')
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Unshallow
         if: github.event.ref_type != 'tag'
         run: |
           git fetch --prune --unshallow
           git tag -d $(git tag --points-at HEAD)
+
       - name: Install Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-          architecture: ${{ matrix.architecture }}
-      - name: Built Distribution
+          architecture: ${{ matrix.arch }}
+
+      - name: Install Build Tools
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          pip install -U git+https://github.com/pypa/setuptools_scm.git@8e6aa2b5fd42cb257c86e6dbe720eaee6d1e2c9b
-          python setup.py bdist_wheel
-          SCM_VERSION=$(python setup.py --version)
-          echo "::set-env name=SCM_VERSION::$SCM_VERSION"
+          pip install -U git+https://github.com/pypa/setuptools_scm.git@8e6aa2b5
+
       - name: Source Distribution
         if: strategy.job-index == 0
         run: python setup.py sdist
+
+      - name: Wheel Distribution
+        # Impure Linux wheels are built in the manylinux job.
+        if: (env.PURE == 'true' && strategy.job-index == 0) || (env.PURE == 'false' && runner.os != 'Linux')
+        run: python setup.py bdist_wheel
+
       - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+        if: strategy.job-index == 0 || (env.PURE == 'false' && runner.os != 'Linux')
+        uses: actions/upload-artifact@v2
         with:
           name: dist
           path: ./dist
 
+      - name: Install Conda
+        run: |
+          if [ $RUNNER_OS == Windows ] && [ ${{ matrix.arch }} == x64 ]; then
+              MINICONDA=Miniconda3-latest-Windows-x86_64.exe
+          elif [ $RUNNER_OS == Windows ]; then
+              MINICONDA=Miniconda3-latest-Windows-x86.exe
+          elif [ $RUNNER_OS == Linux ]; then
+              MINICONDA=Miniconda3-latest-Linux-x86_64.sh
+          else
+              MINICONDA=Miniconda3-latest-MacOSX-x86_64.sh
+          fi
+          curl -LO "https://repo.continuum.io/miniconda/$MINICONDA" 
+          if [ $RUNNER_OS == Windows ]; then
+              cmd //C "$MINICONDA /S /D=%CD%\.miniconda"
+          else
+              bash "$MINICONDA" -b -p .miniconda
+          fi
+          source .miniconda/etc/profile.d/conda.sh
+          conda activate
+          conda create -n py${{ matrix.python }} python=${{ matrix.python }}
+        
+      - name: Build Conda Package
+        run: |
+          source .miniconda/etc/profile.d/conda.sh
+          conda activate py${{ matrix.python }}
+          conda install -c cbillington setuptools_conda
+          pip install -U git+https://github.com/pypa/setuptools_scm.git@8e6aa2b5
+          if [ $NOARCH == true ]; then
+              python setup.py dist_conda --noarch
+          elif [ ${{ matrix.conda_from_wheel }} == true ]; then
+              python setup.py dist_conda --from-wheel
+          else
+              python setup.py dist_conda --pythons ${{ matrix.python }}
+          fi
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: conda_packages
+          path: ./conda_packages
+
+
+  manylinux:
+    name: Build Manylinux
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - { python: 'cp36-cp36m cp37-cp37m cp38-cp38' }
+
+    if: github.repository == 'rpanderson/workflow-sandbox' && (github.event_name != 'create' || github.event.ref_type != 'branch')
+    steps:
+      - name: Checkout
+        if: env.PURE == 'false'
+        uses: actions/checkout@v2
+
+      - name: Unshallow
+        if: github.event.ref_type != 'tag' && env.PURE == 'false'
+        run: |
+          git fetch --prune --unshallow
+          git tag -d $(git tag --points-at HEAD)
+
+      - name: Build Manylinux Wheels
+        if: env.PURE == 'false'
+        uses: RalfG/python-wheels-manylinux-build@v0.2.2-manylinux2010_x86_64
+        with:
+          python-versions: ${{ matrix.python }}
+          build-requirements: git+https://github.com/pypa/setuptools_scm.git@8e6aa2b5
+
+      - name: Upload Artifact
+        if: env.PURE == 'false'
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: wheelhouse/*manylinux*.whl
+
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, manylinux]
     steps:
+
       - name: Download Artifact
         uses: actions/download-artifact@v2
         with:
           name: dist
           path: ./dist
-      - name: Publish on TestPyPI
-        uses: pypa/gh-action-pypi-publish@master
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
         with:
-          user: __token__
-          password: ${{ secrets.testpypi }}
-          repository_url: https://test.pypi.org/legacy/
+          name: conda_packages
+          path: ./conda_packages
+
+      # - name: Publish on TestPyPI
+      #   uses: pypa/gh-action-pypi-publish@master
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.testpypi }}
+      #     repository_url: https://test.pypi.org/legacy/
+
       - name: Get Version Number
         if: github.event.ref_type == 'tag'
         run: |
           VERSION="${GITHUB_REF/refs\/tags\/v/}"
           echo "::set-env name=VERSION::$VERSION"
+
       - name: Create GitHub Release
         if: github.event.ref_type == 'tag'
         id: create_release
@@ -88,6 +214,7 @@ jobs:
           release_name: ${{ env.PACKAGE_NAME }} ${{ env.VERSION }}
           draft: true
           prerelease: ${{ contains(github.event.ref, 'rc') }}
+
       - name: Upload Release Asset
         if: github.event.ref_type == 'tag'
         uses: actions/upload-release-asset@v1
@@ -98,9 +225,41 @@ jobs:
           asset_path: ./dist/${{ env.PACKAGE_NAME }}-${{ env.VERSION }}.tar.gz
           asset_name: ${{ env.PACKAGE_NAME }}-${{ env.VERSION }}.tar.gz
           asset_content_type: application/gzip
+
       - name: Publish on PyPI
         if: github.event.ref_type == 'tag'
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
           password: ${{ secrets.pypi }}
+
+      - name: Install Miniconda and cloud client
+        run: |
+          curl -LO https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh 
+          bash Miniconda3-latest-Linux-x86_64.sh -b -p .miniconda
+          source .miniconda/etc/profile.d/conda.sh
+          conda activate
+          conda install anaconda-client
+
+      # - name: Publish to Anaconda test label
+      #   if: github.event.ref_type != 'tag'
+      #   run: |
+      #     source .miniconda/etc/profile.d/conda.sh
+      #     conda activate
+      #     anaconda \
+      #       --token ${{ secrets.ANACONDA_API_TOKEN }} \
+      #       upload \
+      #       --user $ANACONDA_USER \
+      #       --label test \
+      #       conda_packages/*/*
+              
+      - name: Publish to Anaconda main label
+        if: github.event.ref_type == 'tag'
+        run: |
+          source .miniconda/etc/profile.d/conda.sh
+          conda activate
+          anaconda \
+            --token ${{ secrets.ANACONDA_API_TOKEN }} \
+            upload \
+            --user $ANACONDA_USER \
+            conda_packages/*/*


### PR DESCRIPTION
Add env vars `PURE` and `NOARCH` to specify if the package is a pure Python
package, and if it has platform/python-version-independent dependencies
respectively

Extend the build job so that it:
- Builds wheels on all platforms except Linux if `PURE == false`, and a single universal wheel otherwise.
- Builds conda packages on all platforms if `NOARCH == false`, and a single universal package otherwise.

Add manylinux job that builds impure Linux wheels on the PyPA-provided docker image

Add upload steps for Anaconda cloud

Anaconda upload will not work unless the `rpanderson` Anaconda cloud account is created and an API key added to the github repo.

Addresses issue #17