### PR TITLE
Read and install `setup_requires` from `setup.cfg` instead of hard-coding build requirements in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,9 @@ name: Build and Release
 on:
   push:
     branches:
-      - master
-      - maintenance/*
+      - get-setup-requires
+      # - master
+      # - maintenance/*
   create:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
@@ -20,13 +21,13 @@ env:
   ANACONDA_USER: rpanderson
 
   # Configuration for a package with compiled extensions:
-  # PURE: false
-  # NOARCH: false
+  PURE: false
+  NOARCH: false
 
   # Configuration for a package with no extensions, but with dependencies that differ by
   # platform or Python version:
-  PURE: true
-  NOARCH: false
+  # PURE: true
+  # NOARCH: false
 
   # Configuration for a package with no extensions and the same dependencies on all
   # platforms and Python versions. For this configuration you should comment out all but
@@ -34,6 +35,18 @@ env:
   # needed.
   # PURE: true
   # NOARCH: true
+
+  STEP_GET_BUILD_REQUIREMENTS: |
+    SETUP_REQUIRES=$(python -c '\
+    import configparser as p
+    c = p.ConfigParser(inline_comment_prefixes=";")
+    c.read("setup.cfg")
+    requirements = c.get("options", "setup_requires").splitlines()
+    if "setuptools_scm" in requirements: # Just until we stop using the git version
+        requirements.remove("setuptools_scm")
+    print(*[s.replace(" ", "") for s in requirements if s])')
+    echo "::set-env name=SETUP_REQUIRES::$SETUP_REQUIRES"
+
 
 jobs:
   build:
@@ -75,9 +88,15 @@ jobs:
           python-version: ${{ matrix.python }}
           architecture: ${{ matrix.arch }}
 
+      - name: Get Build Requirements
+        run: ${{ env.STEP_GET_BUILD_REQUIREMENTS }}
+
       - name: Install Build Tools
         run: |
           python -m pip install --upgrade pip setuptools wheel
+          if [ ! -z "$SETUP_REQUIRES" ]; then
+            pip install $SETUP_REQUIRES
+          fi
           pip install -U git+https://github.com/pypa/setuptools_scm.git@8e6aa2b5
 
       - name: Source Distribution
@@ -122,6 +141,9 @@ jobs:
           source .miniconda/etc/profile.d/conda.sh
           conda activate py${{ matrix.python }}
           conda install -c cbillington setuptools_conda
+          if [ ! -z "$SETUP_REQUIRES" ]; then
+            conda install $SETUP_REQUIRES
+          fi
           pip install -U git+https://github.com/pypa/setuptools_scm.git@8e6aa2b5
           if [ $NOARCH == true ]; then
               python setup.py dist_conda --noarch
@@ -158,12 +180,19 @@ jobs:
           git fetch --prune --unshallow
           git tag -d $(git tag --points-at HEAD)
 
+      - name: Install Python
+        uses: actions/setup-python@v2
+
+      - name: Get Build Requirements
+        run: ${{ env.STEP_GET_BUILD_REQUIREMENTS }}
+
       - name: Build Manylinux Wheels
         if: env.PURE == 'false'
         uses: RalfG/python-wheels-manylinux-build@v0.2.2-manylinux2010_x86_64
         with:
           python-versions: ${{ matrix.python }}
-          build-requirements: git+https://github.com/pypa/setuptools_scm.git@8e6aa2b5
+          build-requirements: git+https://github.com/pypa/setuptools_scm.git@8e6aa2b5 ${{ env.SETUP_REQUIRES }}
+          pip-wheel-args: '--no-deps --no-build-isolation'
 
       - name: Upload Artifact
         if: env.PURE == 'false'
@@ -190,12 +219,12 @@ jobs:
           name: conda_packages
           path: ./conda_packages
 
-      - name: Publish on TestPyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.testpypi }}
-          repository_url: https://test.pypi.org/legacy/
+      # - name: Publish on TestPyPI
+      #   uses: pypa/gh-action-pypi-publish@master
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.testpypi }}
+      #     repository_url: https://test.pypi.org/legacy/
 
       - name: Get Version Number
         if: github.event.ref_type == 'tag'
@@ -241,17 +270,17 @@ jobs:
           conda activate
           conda install anaconda-client
 
-      - name: Publish to Anaconda test label
-        if: github.event.ref_type != 'tag'
-        run: |
-          source .miniconda/etc/profile.d/conda.sh
-          conda activate
-          anaconda \
-            --token ${{ secrets.ANACONDA_API_TOKEN }} \
-            upload \
-            --user $ANACONDA_USER \
-            --label test \
-            conda_packages/*/*
+      # - name: Publish to Anaconda test label
+      #   if: github.event.ref_type != 'tag'
+      #   run: |
+      #     source .miniconda/etc/profile.d/conda.sh
+      #     conda activate
+      #     anaconda \
+      #       --token ${{ secrets.ANACONDA_API_TOKEN }} \
+      #       upload \
+      #       --user $ANACONDA_USER \
+      #       --label test \
+      #       conda_packages/*/*
 
       - name: Publish to Anaconda main label
         if: github.event.ref_type == 'tag'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,9 +180,11 @@ jobs:
           git tag -d $(git tag --points-at HEAD)
 
       - name: Install Python
+        if: env.PURE == 'false'
         uses: actions/setup-python@v2
 
       - name: Get Build Requirements
+        if: env.PURE == 'false'
         run: ${{ env.STEP_GET_BUILD_REQUIREMENTS }}
 
       - name: Build Manylinux Wheels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,8 @@ name: Build and Release
 on:
   push:
     branches:
-      - get-setup-requires
-      # - master
-      # - maintenance/*
+      - master
+      - maintenance/*
   create:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
@@ -21,13 +20,13 @@ env:
   ANACONDA_USER: rpanderson
 
   # Configuration for a package with compiled extensions:
-  PURE: false
-  NOARCH: false
+  # PURE: false
+  # NOARCH: false
 
   # Configuration for a package with no extensions, but with dependencies that differ by
   # platform or Python version:
-  # PURE: true
-  # NOARCH: false
+  PURE: true
+  NOARCH: false
 
   # Configuration for a package with no extensions and the same dependencies on all
   # platforms and Python versions. For this configuration you should comment out all but
@@ -219,12 +218,12 @@ jobs:
           name: conda_packages
           path: ./conda_packages
 
-      # - name: Publish on TestPyPI
-      #   uses: pypa/gh-action-pypi-publish@master
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.testpypi }}
-      #     repository_url: https://test.pypi.org/legacy/
+      - name: Publish on TestPyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.testpypi }}
+          repository_url: https://test.pypi.org/legacy/
 
       - name: Get Version Number
         if: github.event.ref_type == 'tag'
@@ -270,17 +269,17 @@ jobs:
           conda activate
           conda install anaconda-client
 
-      # - name: Publish to Anaconda test label
-      #   if: github.event.ref_type != 'tag'
-      #   run: |
-      #     source .miniconda/etc/profile.d/conda.sh
-      #     conda activate
-      #     anaconda \
-      #       --token ${{ secrets.ANACONDA_API_TOKEN }} \
-      #       upload \
-      #       --user $ANACONDA_USER \
-      #       --label test \
-      #       conda_packages/*/*
+      - name: Publish to Anaconda test label
+        if: github.event.ref_type != 'tag'
+        run: |
+          source .miniconda/etc/profile.d/conda.sh
+          conda activate
+          anaconda \
+            --token ${{ secrets.ANACONDA_API_TOKEN }} \
+            upload \
+            --user $ANACONDA_USER \
+            --label test \
+            conda_packages/*/*
 
       - name: Publish to Anaconda main label
         if: github.event.ref_type == 'tag'


### PR DESCRIPTION
Read setup_requires from setup.cfg and automatically install before builds

This is for example for runviewer, which has `cython` as a build-time dependency. And `setuptools_scm` as a build-time dependency should not be a special case (other than the fact that we want to use a git version of it). This patch solves that problem for now, but read onward for a
discussion (this turned out to be a total rabbit hole) and alternate solutions.

(TL;DR, maybe we wait until we don't need a git version of `setuptools_scm`, and then we put build requirements in `pyproject.toml` such that pip will process them automatically)

Set `--no-build-isolation` in the manylinux action, because it uses `pip wheel` to build the wheels, and the mere existence of a `pyproject.toml` (used here solely for configuring `black`, see https://github.com/psf/black/issues/683) causes pip to build the wheels in an isolated environment, devoid of our actual build dependencies since we are not declaring build dependencies in `pyproject.toml` as this new PEP 517/518 mechanism (that introduced `pyproject.toml`) would have us do.

Actually abandoning `setup_requires` (the contents of which there exists no mechanism to automatically install without running setup.py first - other than parsing `setup.cfg` ourselves as is done here) and putting build dependencies in `pyproject.toml` is another option. However, this
will prevent us from injecting additional build-time dependencies like we are doing with `setuptools_scm`. We could list the git version of `setuptools_scm` as a build-time dependency in `pyproject.toml`, but conda won't understand that - at the moment we're just hackily pip-installing the git version of `setuptools_conda` in the conda environment.

Once `setuptools_scm` releases with the `release-branch-semver` scheme (they released yesterday, but alas in their own migration from `setup.py` to `setup.cfg` they didn't migrate the new scheme!
https://github.com/pypa/setuptools_scm/pull/441), this is probably moot and we could declare build dependencies in `pyproject.toml` - I don't imagine we'll be using git versions of build dependencies very often. Then pip could build wheels for us in accordance with PEP 517 without us having to install build dependencies ourselves at all.

However the bootstrapping issue for `setuptools_conda` will remain - how will it know that you need to install `cython` in order to run `setup.py`, when no `setuptools_conda` code runs until you're already running `setup.py`? It will presumably require an external tool to let you say:
```bash
$ setuptools_conda . dist_conda [args]
```
instead of
```bash
$ python setup.py dist_conda [args]
```

so that it has a chance to parse some `toml` and install the build-dependencies before running `setup.py`.