### PR TITLE
Install build requirements and build using pep517

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,9 @@ name: Build and Release
 on:
   push:
     branches:
-      - master
-      - maintenance/*
+      - pep517
+      # - master
+      # - maintenance/*
   create:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
@@ -75,19 +76,18 @@ jobs:
           python-version: ${{ matrix.python }}
           architecture: ${{ matrix.arch }}
 
-      - name: Install Build Tools
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
-          pip install -U git+https://github.com/pypa/setuptools_scm.git@8e6aa2b5
-
       - name: Source Distribution
         if: strategy.job-index == 0
-        run: python setup.py sdist
+        run: |
+          pip install pep517
+          python -m pep517.build -s .
 
       - name: Wheel Distribution
         # Impure Linux wheels are built in the manylinux job.
         if: (env.PURE == 'true' && strategy.job-index == 0) || (env.PURE == 'false' && runner.os != 'Linux')
-        run: python setup.py bdist_wheel
+        run: |
+          pip install pep517
+          python -m pep517.build -b .
 
       - name: Upload Artifact
         if: strategy.job-index == 0 || (env.PURE == 'false' && runner.os != 'Linux')
@@ -202,12 +202,12 @@ jobs:
           name: conda_packages
           path: ./conda_packages
 
-      - name: Publish on TestPyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.testpypi }}
-          repository_url: https://test.pypi.org/legacy/
+      # - name: Publish on TestPyPI
+      #   uses: pypa/gh-action-pypi-publish@master
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.testpypi }}
+      #     repository_url: https://test.pypi.org/legacy/
 
       - name: Get Version Number
         if: github.event.ref_type == 'tag'
@@ -253,17 +253,17 @@ jobs:
           conda activate
           conda install anaconda-client
 
-      - name: Publish to Anaconda test label
-        if: github.event.ref_type != 'tag'
-        run: |
-          source .miniconda/etc/profile.d/conda.sh
-          conda activate
-          anaconda \
-            --token ${{ secrets.ANACONDA_API_TOKEN }} \
-            upload \
-            --user $ANACONDA_USER \
-            --label test \
-            conda_packages/*/*
+      # - name: Publish to Anaconda test label
+      #   if: github.event.ref_type != 'tag'
+      #   run: |
+      #     source .miniconda/etc/profile.d/conda.sh
+      #     conda activate
+      #     anaconda \
+      #       --token ${{ secrets.ANACONDA_API_TOKEN }} \
+      #       upload \
+      #       --user $ANACONDA_USER \
+      #       --label test \
+      #       conda_packages/*/*
 
       - name: Publish to Anaconda main label
         if: github.event.ref_type == 'tag'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,8 @@ name: Build and Release
 on:
   push:
     branches:
-      - pep517
-      # - master
-      # - maintenance/*
+      - master
+      - maintenance/*
   create:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
@@ -201,12 +200,12 @@ jobs:
           name: conda_packages
           path: ./conda_packages
 
-      # - name: Publish on TestPyPI
-      #   uses: pypa/gh-action-pypi-publish@master
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.testpypi }}
-      #     repository_url: https://test.pypi.org/legacy/
+      - name: Publish on TestPyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.testpypi }}
+          repository_url: https://test.pypi.org/legacy/
 
       - name: Get Version Number
         if: github.event.ref_type == 'tag'
@@ -252,17 +251,17 @@ jobs:
           conda activate
           conda install anaconda-client
 
-      # - name: Publish to Anaconda test label
-      #   if: github.event.ref_type != 'tag'
-      #   run: |
-      #     source .miniconda/etc/profile.d/conda.sh
-      #     conda activate
-      #     anaconda \
-      #       --token ${{ secrets.ANACONDA_API_TOKEN }} \
-      #       upload \
-      #       --user $ANACONDA_USER \
-      #       --label test \
-      #       conda_packages/*/*
+      - name: Publish to Anaconda test label
+        if: github.event.ref_type != 'tag'
+        run: |
+          source .miniconda/etc/profile.d/conda.sh
+          conda activate
+          anaconda \
+            --token ${{ secrets.ANACONDA_API_TOKEN }} \
+            upload \
+            --user $ANACONDA_USER \
+            --label test \
+            conda_packages/*/*
 
       - name: Publish to Anaconda main label
         if: github.event.ref_type == 'tag'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,6 @@ jobs:
         uses: RalfG/python-wheels-manylinux-build@v0.2.2-manylinux2010_x86_64
         with:
           python-versions: ${{ matrix.python }}
-          build-requirements: git+https://github.com/pypa/setuptools_scm.git@8e6aa2b5
 
       - name: Upload Artifact
         if: env.PURE == 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,14 +79,14 @@ jobs:
       - name: Source Distribution
         if: strategy.job-index == 0
         run: |
-          pip install pep517
+          python -m pip install --upgrade pip setuptools wheel pep517
           python -m pep517.build -s .
 
       - name: Wheel Distribution
         # Impure Linux wheels are built in the manylinux job.
         if: (env.PURE == 'true' && strategy.job-index == 0) || (env.PURE == 'false' && runner.os != 'Linux')
         run: |
-          pip install pep517
+          python -m pip install --upgrade pip setuptools wheel pep517
           python -m pep517.build -b .
 
       - name: Upload Artifact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools", "wheel", "setuptools_scm"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 88
 skip-string-normalization = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,6 @@ install_requires =
   importlib_metadata>=1.0 ; python_version < '3.8'
   pywin32>=227 ; sys_platform == 'win32'
   setuptools
-setup_requires =
-  setuptools_scm
 
 [options.extras_require]
 development = 


### PR DESCRIPTION
Install build requirements and build using pep517

PEP517 requires projects to list their build dependencies and build
system (setuptools for us) in pyproject.toml. Build tools like pip can
then know how to build the package, installing their build dependencies
automatically (in an isolated environment such that they are not
installed in your current environment) and then running the build system
to build a wheel or sdist.

Most people use pip to build wheels for projects that use this
mechanism. But pip hasn't implemented the sdist part of it yet, which
would leave us still manually installing dependencies just to make
sdists.

So whilst the Python packaging authority makes up its mind where the
general-purpose PEP517 build commands belong, we use the reference
implementation package `pep517` (which IMHO should just be given a
better name and become the blessed tool for PEP517 builds).