### PR TITLE
Run conda build via cmd.exe on Windows.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,8 @@ name: Build and Release
 on:
   push:
     branches:
-      - conda-fixes
-      # - master
-      # - maintenance/*
+      - master
+      - maintenance/*
   create:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
@@ -203,12 +202,12 @@ jobs:
           name: conda_packages
           path: ./conda_packages
 
-      # - name: Publish on TestPyPI
-      #   uses: pypa/gh-action-pypi-publish@master
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.testpypi }}
-      #     repository_url: https://test.pypi.org/legacy/
+      - name: Publish on TestPyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.testpypi }}
+          repository_url: https://test.pypi.org/legacy/
 
       - name: Get Version Number
         if: github.event.ref_type == 'tag'
@@ -254,17 +253,17 @@ jobs:
           conda activate
           conda install anaconda-client
 
-      # - name: Publish to Anaconda test label
-      #   if: github.event.ref_type != 'tag'
-      #   run: |
-      #     source .miniconda/etc/profile.d/conda.sh
-      #     conda activate
-      #     anaconda \
-      #       --token ${{ secrets.ANACONDA_API_TOKEN }} \
-      #       upload \
-      #       --user $ANACONDA_USER \
-      #       --label test \
-      #       conda_packages/*/*
+      - name: Publish to Anaconda test label
+        if: github.event.ref_type != 'tag'
+        run: |
+          source .miniconda/etc/profile.d/conda.sh
+          conda activate
+          anaconda \
+            --token ${{ secrets.ANACONDA_API_TOKEN }} \
+            upload \
+            --user $ANACONDA_USER \
+            --label test \
+            conda_packages/*/*
 
       - name: Publish to Anaconda main label
         if: github.event.ref_type == 'tag'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,9 @@ name: Build and Release
 on:
   push:
     branches:
-      - master
-      - maintenance/*
+      - conda-fixes
+      # - master
+      # - maintenance/*
   create:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
@@ -42,21 +43,21 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: ubuntu-latest,   python: 3.8,  arch: x64, conda_fromwheel: false }
-          - { os: ubuntu-latest,   python: 3.7,  arch: x64, conda_fromwheel: false }
-          - { os: ubuntu-latest,   python: 3.6,  arch: x64, conda_fromwheel: false }
+          - { os: ubuntu-latest,   python: 3.8,  arch: x64 }
+          - { os: ubuntu-latest,   python: 3.7,  arch: x64 }
+          - { os: ubuntu-latest,   python: 3.6,  arch: x64 }
 
-          - { os: macos-latest,    python: 3.8,  arch: x64, conda_fromwheel: false }
-          - { os: macos-latest,    python: 3.7,  arch: x64, conda_fromwheel: false }
-          - { os: macos-latest,    python: 3.6,  arch: x64, conda_fromwheel: false }
+          - { os: macos-latest,    python: 3.8,  arch: x64 }
+          - { os: macos-latest,    python: 3.7,  arch: x64 }
+          - { os: macos-latest,    python: 3.6,  arch: x64 }
 
-          - { os: windows-latest,  python: 3.8,  arch: x64, conda_fromwheel: true  }
-          - { os: windows-latest,  python: 3.7,  arch: x64, conda_fromwheel: true  }
-          - { os: windows-latest,  python: 3.6,  arch: x64, conda_fromwheel: true  }
+          - { os: windows-latest,  python: 3.8,  arch: x64 }
+          - { os: windows-latest,  python: 3.7,  arch: x64 }
+          - { os: windows-latest,  python: 3.6,  arch: x64 }
 
-          - { os: windows-latest,  python: 3.8,  arch: x86, conda_fromwheel: true  }
-          - { os: windows-latest,  python: 3.7,  arch: x86, conda_fromwheel: true  }
-          - { os: windows-latest,  python: 3.6,  arch: x86, conda_fromwheel: true  }
+          - { os: windows-latest,  python: 3.8,  arch: x86 }
+          - { os: windows-latest,  python: 3.7,  arch: x86 }
+          - { os: windows-latest,  python: 3.6,  arch: x86 }
 
     if: github.repository == 'rpanderson/workflow-sandbox' && (github.event_name != 'create' || github.event.ref_type != 'branch')
     steps:
@@ -96,40 +97,52 @@ jobs:
           name: dist
           path: ./dist
 
-      - name: Install Conda
+      - name: Set Variables for Conda Build
         run: |
           if [ $RUNNER_OS == Windows ] && [ ${{ matrix.arch }} == x64 ]; then
-              MINICONDA=Miniconda3-latest-Windows-x86_64.exe
+              CONDA_INSTALLER=Miniconda3-latest-Windows-x86_64.exe
           elif [ $RUNNER_OS == Windows ]; then
-              MINICONDA=Miniconda3-latest-Windows-x86.exe
+              CONDA_INSTALLER=Miniconda3-latest-Windows-x86.exe
           elif [ $RUNNER_OS == Linux ]; then
-              MINICONDA=Miniconda3-latest-Linux-x86_64.sh
+              CONDA_INSTALLER=Miniconda3-latest-Linux-x86_64.sh
           else
-              MINICONDA=Miniconda3-latest-MacOSX-x86_64.sh
+              CONDA_INSTALLER=Miniconda3-latest-MacOSX-x86_64.sh
           fi
-          curl -LO "https://repo.continuum.io/miniconda/$MINICONDA" 
-          if [ $RUNNER_OS == Windows ]; then
-              cmd //C "$MINICONDA /S /D=%CD%\.miniconda"
+          if [ $NOARCH == true ]; then
+              CONDA_BUILD_ARGS="--noarch"
           else
-              bash "$MINICONDA" -b -p .miniconda
+              CONDA_BUILD_ARGS=""
           fi
+          echo "::set-env name=CONDA_INSTALLER::$CONDA_INSTALLER"
+          echo "::set-env name=CONDA_BUILD_ARGS::$CONDA_BUILD_ARGS"
+
+      - name: Conda package (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          curl -LO https://repo.continuum.io/miniconda/$CONDA_INSTALLER
+          bash "$CONDA_INSTALLER" -b -p .miniconda
           source .miniconda/etc/profile.d/conda.sh
           conda activate
+          conda update -n base -c defaults conda
           conda create -n py${{ matrix.python }} python=${{ matrix.python }}
-
-      - name: Build Conda Package
-        run: |
-          source .miniconda/etc/profile.d/conda.sh
           conda activate py${{ matrix.python }}
-          conda install -c cbillington setuptools_conda
-          pip install -U git+https://github.com/pypa/setuptools_scm.git@8e6aa2b5
-          if [ $NOARCH == true ]; then
-              python setup.py dist_conda --noarch
-          elif [ ${{ matrix.conda_from_wheel }} == true ]; then
-              python setup.py dist_conda --from-wheel
-          else
-              python setup.py dist_conda --pythons ${{ matrix.python }}
-          fi
+          conda install -c cbillington setuptools-conda
+          pip install --upgrade setuptools_scm
+          setuptools-conda build $CONDA_BUILD_ARGS .
+
+      - name: Conda Package (Windows)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          curl -LO https://repo.continuum.io/miniconda/%CONDA_INSTALLER%
+          %CONDA_INSTALLER% /S /D=%CD%\.miniconda && ^
+          .miniconda\Scripts\activate && ^
+          conda update -n base -c defaults conda && ^
+          conda create -n py${{ matrix.python }} python=${{ matrix.python }} && ^
+          conda activate py${{ matrix.python }} && ^
+          conda install -c cbillington setuptools-conda && ^
+          pip install --upgrade setuptools_scm && ^
+          setuptools-conda build %CONDA_BUILD_ARGS% .
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
@@ -190,12 +203,12 @@ jobs:
           name: conda_packages
           path: ./conda_packages
 
-      - name: Publish on TestPyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.testpypi }}
-          repository_url: https://test.pypi.org/legacy/
+      # - name: Publish on TestPyPI
+      #   uses: pypa/gh-action-pypi-publish@master
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.testpypi }}
+      #     repository_url: https://test.pypi.org/legacy/
 
       - name: Get Version Number
         if: github.event.ref_type == 'tag'
@@ -241,17 +254,17 @@ jobs:
           conda activate
           conda install anaconda-client
 
-      - name: Publish to Anaconda test label
-        if: github.event.ref_type != 'tag'
-        run: |
-          source .miniconda/etc/profile.d/conda.sh
-          conda activate
-          anaconda \
-            --token ${{ secrets.ANACONDA_API_TOKEN }} \
-            upload \
-            --user $ANACONDA_USER \
-            --label test \
-            conda_packages/*/*
+      # - name: Publish to Anaconda test label
+      #   if: github.event.ref_type != 'tag'
+      #   run: |
+      #     source .miniconda/etc/profile.d/conda.sh
+      #     conda activate
+      #     anaconda \
+      #       --token ${{ secrets.ANACONDA_API_TOKEN }} \
+      #       upload \
+      #       --user $ANACONDA_USER \
+      #       --label test \
+      #       conda_packages/*/*
 
       - name: Publish to Anaconda main label
         if: github.event.ref_type == 'tag'

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+conda_build/
+conda_packages/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template


### PR DESCRIPTION
It turns out (almost) all our conda woes are caused by using it in git
bash on Windows. Running it in `cmd.exe` instead, the `--from-wheel`
workaround is not necessary.

Regardless of the `--from-wheel` workaround, `setuptools-conda` has
grown the ability to install build dependencies from a `pyproject.toml`
or `setup.cfg`, and I was not able to get it to run `conda install` in a
subprocess without mysterious and subtle failures.

This fix uses `setuptools-conda`'s new invocation as
```bash
$ setuptools-conda build [args] .
```

And has a separate step for Windows and Unix so that cmd.exe can be used
in Windows.