### PR TITLE
Use release-branch-semver and build for Python 3.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,18 +42,22 @@ jobs:
     strategy:
       matrix:
         include:
+          - { os: ubuntu-latest,   python: 3.9,  arch: x64 }
           - { os: ubuntu-latest,   python: 3.8,  arch: x64 }
           - { os: ubuntu-latest,   python: 3.7,  arch: x64 }
           - { os: ubuntu-latest,   python: 3.6,  arch: x64 }
 
+          - { os: macos-latest,    python: 3.9,  arch: x64 }
           - { os: macos-latest,    python: 3.8,  arch: x64 }
           - { os: macos-latest,    python: 3.7,  arch: x64 }
           - { os: macos-latest,    python: 3.6,  arch: x64 }
 
+          - { os: windows-latest,  python: 3.9,  arch: x64 }
           - { os: windows-latest,  python: 3.8,  arch: x64 }
           - { os: windows-latest,  python: 3.7,  arch: x64 }
           - { os: windows-latest,  python: 3.6,  arch: x64 }
 
+          - { os: windows-latest,  python: 3.9,  arch: x86 }
           - { os: windows-latest,  python: 3.8,  arch: x86 }
           - { os: windows-latest,  python: 3.7,  arch: x86 }
           - { os: windows-latest,  python: 3.6,  arch: x86 }
@@ -155,7 +159,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { python: 'cp36-cp36m cp37-cp37m cp38-cp38' }
+          - { python: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39' }
 
     if: github.repository == 'rpanderson/workflow-sandbox' && (github.event_name != 'create' || github.event.ref_type != 'branch')
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ defaults:
 
 env:
   PACKAGE_NAME: workflow-sandbox
-  SCM_VERSION_SCHEME: release-branch-semver
   SCM_LOCAL_SCHEME: no-local-version
   ANACONDA_USER: rpanderson
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Dummy project used to test GitHub actions and Cirrus CI for building and publishing releases of Python packages.
 
-This will be a (dummy) Python package on test PyPI in its own right, with package name `workflow-sandbox` and module name `workflow_sandbox`.
+This will be a (dummy) Python package on test PyPI and Anacnoda Cloud in its own right, with package name `workflow-sandbox` and module name `workflow_sandbox`.
 
 ## Practices
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm"]
+requires = ["setuptools", "wheel", "setuptools_scm>=4.1.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
 skip-string-normalization = true
-target_version = ['py36', 'py37', 'py38']
+target_version = ['py36', 'py37', 'py38', 'py39']
 include = '\.pyi?$'
 exclude = '''
 (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=4.1.0"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm>=4.1.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm>=4.1.0"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=4.1.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ python_requires = >=3.6
 install_requires =
   importlib_metadata>=1.0 ; python_version < '3.8'
   pywin32>=227 ; sys_platform == 'win32'
+  setuptools_scm>=4.1.0
   setuptools
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9    
     Topic :: Software Development :: Testing
     Topic :: Software Development :: Version Control :: Git
     Topic :: System :: Archiving :: Packaging

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 import os
 from setuptools import setup
 
-VERSION_SCHEME = {}
-VERSION_SCHEME["version_scheme"] = os.environ.get(
-    "SCM_VERSION_SCHEME", "release-branch-semver"
-)
-VERSION_SCHEME["local_scheme"] = os.environ.get("SCM_LOCAL_SCHEME", "node-and-date")
+VERSION_SCHEME = {
+    "version_scheme": "release-branch-semver",
+    "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
+}
 
 setup(use_scm_version=VERSION_SCHEME)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 VERSION_SCHEME = {}
 VERSION_SCHEME["version_scheme"] = os.environ.get(
-    "SCM_VERSION_SCHEME", "guess-next-dev"
+    "SCM_VERSION_SCHEME", "release-branch-semver"
 )
 VERSION_SCHEME["local_scheme"] = os.environ.get("SCM_LOCAL_SCHEME", "node-and-date")
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -3,6 +3,5 @@ import workflow_sandbox
 
 
 def test_version():
-    """Check version against `pkg_resources` from `setuptools`.
-    """
+    """Check version against `pkg_resources` from `setuptools`."""
     assert workflow_sandbox.__version__ == get_distribution('workflow_sandbox').version

--- a/workflow_sandbox/__version__.py
+++ b/workflow_sandbox/__version__.py
@@ -9,7 +9,7 @@ except ImportError:
     import importlib_metadata
 
 VERSION_SCHEME = {
-    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "guess-next-dev"),
+    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "release-branch-semver"),
     "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
 }
 

--- a/workflow_sandbox/__version__.py
+++ b/workflow_sandbox/__version__.py
@@ -8,17 +8,16 @@ except ImportError:
     # The backport of the Python 3.8 stdlib module
     import importlib_metadata
 
-VERSION_SCHEME = {
-    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "release-branch-semver"),
-    "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
-}
-
 root = Path(__file__).parent.parent
 if (root / '.git').is_dir():
     # Use setuptools_scm when in a git repository
     from setuptools_scm import get_version
 
-    __version__ = get_version(root, **VERSION_SCHEME)
+    __version__ = get_version(
+        root,
+        version_scheme="release-branch-semver",
+        local_scheme=os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
+    )
 else:
     # Get the version at runtime from PEP-0566 metadata using `importlib.metadata`
     # from the standard library or the `importlib_metadata` backport

--- a/workflow_sandbox/__version__.py
+++ b/workflow_sandbox/__version__.py
@@ -3,10 +3,10 @@ from pathlib import Path
 
 try:
     # Standard library in Python 3.8+
-    import importlib.metadata as importlib_metadata
+    from importlib.metadata import version, PackageNotFoundError
 except ImportError:
     # The backport of the Python 3.8 stdlib module
-    import importlib_metadata
+    from importlib_metadata import version, PackageNotFoundError
 
 root = Path(__file__).parent.parent
 if (root / '.git').is_dir():
@@ -22,6 +22,6 @@ else:
     # Get the version at runtime from PEP-0566 metadata using `importlib.metadata`
     # from the standard library or the `importlib_metadata` backport
     try:
-        __version__ = importlib_metadata.version(__package__)
-    except importlib_metadata.PackageNotFoundError:
+        __version__ = version(__package__)
+    except PackageNotFoundError:
         __version__ = None


### PR DESCRIPTION
Long time coming update to use `release-branch-semver` like it says on the packet, and builds for Python 3.9.