### PR TITLE
Workaround conda-build incompatibility with xcode 12+

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,12 @@ jobs:
           architecture: ${{ matrix.arch }}
           miniconda-version: "latest"
 
+      - name: Workaround conda-build incompatibility with xcode >12
+        if: runner.os == 'macOS'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 11.7
+          
       - name: Conda package (Unix)
         if: runner.os != 'Windows'
         run: |


### PR DESCRIPTION
This is necessary to build C extensions on macos, and can presumably be removed in
the future once conda-build works with the newer xcode.