### PR TITLE
Add Python 3.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,25 +41,29 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: ubuntu-latest,   python: 3.9,  arch: x64 }
-          - { os: ubuntu-latest,   python: 3.8,  arch: x64 }
-          - { os: ubuntu-latest,   python: 3.7,  arch: x64 }
-          - { os: ubuntu-latest,   python: 3.6,  arch: x64 }
+          - { os: ubuntu-latest,   python: '3.10',  arch: x64 }
+          - { os: ubuntu-latest,   python: '3.9',  arch: x64 }
+          - { os: ubuntu-latest,   python: '3.8',  arch: x64 }
+          - { os: ubuntu-latest,   python: '3.7',  arch: x64 }
+          - { os: ubuntu-latest,   python: '3.6',  arch: x64 }
 
-          - { os: macos-latest,    python: 3.9,  arch: x64 }
-          - { os: macos-latest,    python: 3.8,  arch: x64 }
-          - { os: macos-latest,    python: 3.7,  arch: x64 }
-          - { os: macos-latest,    python: 3.6,  arch: x64 }
+          - { os: macos-latest,    python: '3.10',  arch: x64 }
+          - { os: macos-latest,    python: '3.9',  arch: x64 }
+          - { os: macos-latest,    python: '3.8',  arch: x64 }
+          - { os: macos-latest,    python: '3.7',  arch: x64 }
+          - { os: macos-latest,    python: '3.6',  arch: x64 }
 
-          - { os: windows-latest,  python: 3.9,  arch: x64 }
-          - { os: windows-latest,  python: 3.8,  arch: x64 }
-          - { os: windows-latest,  python: 3.7,  arch: x64 }
-          - { os: windows-latest,  python: 3.6,  arch: x64 }
+          - { os: windows-latest,  python: '3.10',  arch: x64 }
+          - { os: windows-latest,  python: '3.9',  arch: x64 }
+          - { os: windows-latest,  python: '3.8',  arch: x64 }
+          - { os: windows-latest,  python: '3.7',  arch: x64 }
+          - { os: windows-latest,  python: '3.6',  arch: x64 }
 
-          - { os: windows-latest,  python: 3.9,  arch: x86 }
-          - { os: windows-latest,  python: 3.8,  arch: x86 }
-          - { os: windows-latest,  python: 3.7,  arch: x86 }
-          - { os: windows-latest,  python: 3.6,  arch: x86 }
+          - { os: windows-latest,  python: '3.10',  arch: x86 }
+          - { os: windows-latest,  python: '3.9',  arch: x86 }
+          - { os: windows-latest,  python: '3.8',  arch: x86 }
+          - { os: windows-latest,  python: '3.7',  arch: x86 }
+          - { os: windows-latest,  python: '3.6',  arch: x86 }
 
     if: github.repository == 'rpanderson/workflow-sandbox' && (github.event_name != 'create' || github.event.ref_type != 'branch')
     steps:
@@ -143,7 +147,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { python: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39' }
+          - { python: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310' }
 
     if: github.repository == 'rpanderson/workflow-sandbox' && (github.event_name != 'create' || github.event.ref_type != 'branch')
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9    
+    Programming Language :: Python :: 3.10
     Topic :: Software Development :: Testing
     Topic :: Software Development :: Version Control :: Git
     Topic :: System :: Archiving :: Packaging


### PR DESCRIPTION
This doesn't work yet as `conda-build` has no 3.10 release, which blocks `setuptools-conda`, which blocks `workflow-sandbox`.

If there is a substantial further delay before `conda-build` gets a 3.10 release, then we ought to modify the workflow to be able to proceed with a PyPI release even if we have to wait longer for a conda package.

Note that quote marks have to be added around the Python version numbers in the workflow now, otherwise they're actually floats and `3.10` parses as `3.1`.