### PR TITLE
Bump/specify the version of some actions used

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Build Manylinux Wheels
         if: env.PURE == 'false'
-        uses: RalfG/python-wheels-manylinux-build@v0.2.2-manylinux2010_x86_64
+        uses: RalfG/python-wheels-manylinux-build@v0.4.0
         with:
           python-versions: ${{ matrix.python }}
 
@@ -189,7 +189,7 @@ jobs:
           path: ./conda_packages
 
       - name: Publish on TestPyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.testpypi }}


### PR DESCRIPTION
The PyPI one was specifying `@master` which is poor practice but was necessary at the time as they hadn't cut any official releases.

The manylinux one was working just fine, but is a good idea to generally keep up.

No need to specify which manylinux image to use, as the defaults suit us.