### PR TITLE
Correct issues leading to failed mac and Linux wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,6 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 
-defaults:
-  run:
-    shell: bash -l {0}
-
 env:
   PACKAGE_NAME: workflow-sandbox
   SCM_LOCAL_SCHEME: no-local-version
@@ -99,6 +95,7 @@ jobs:
           path: ./dist
 
       - name: Set Variables for Conda Build
+        shell: bash
         run: |
           if [ $NOARCH == true ]; then
               CONDA_BUILD_ARGS="--noarch"
@@ -123,9 +120,10 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: 11.7
-          
+
       - name: Conda package (Unix)
         if: runner.os != 'Windows'
+        shell: bash -l {0}
         run: |
           conda install -c labscript-suite setuptools-conda
           setuptools-conda build $CONDA_BUILD_ARGS .
@@ -175,7 +173,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: dist
-          path: wheelhouse/*manylinux*.whl
+          path: dist/*manylinux*.whl
 
   release:
     name: Release
@@ -244,10 +242,12 @@ jobs:
           auto-update-conda: true
 
       - name: Install Anaconda cloud client
+        shell: bash -l {0}
         run: conda install anaconda-client
 
       - name: Publish to Anaconda test label
         if: github.event.ref_type != 'tag'
+        shell: bash -l {0}
         run: |
           anaconda \
             --token ${{ secrets.ANACONDA_API_TOKEN }} \
@@ -257,6 +257,7 @@ jobs:
             conda_packages/*/*
 
       - name: Publish to Anaconda main label
+        shell: bash -l {0}
         if: github.event.ref_type == 'tag'
         run: |
           anaconda \


### PR DESCRIPTION
Firstly, running commands with the shell `bash -l {0}`, which is
required for miniconda to be activated, results in the `python` command
being Python 2 on macos. This means on macos the workflow has been
building Python 2 wheels exclusively 😬.

Secondly, the latest version of the `manylinux` action saves wheels to
`dist/` rather than `wheelhouse/`. So we were not even uploading them.

These issues broke macos and Linux wheels for any non-pure packages
(pure packages only a single wheel is needed as build on ubuntu,
without the manylinux action).