### PR TITLE
Use latest manylinux action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
 
       - name: Build Manylinux Wheels
         if: env.PURE == 'false'
-        uses: RalfG/python-wheels-manylinux-build@v0.4.0
+        uses: RalfG/python-wheels-manylinux-build@v0.4.2
         with:
           python-versions: ${{ matrix.python }}
 


### PR DESCRIPTION
It now defaults to a newer manylinux standard, which I noticed is
necessary to compile labscript-c-extensions.

We unfortunately can't specify "0.4" to automatically use the latest
0.4.x version of the action.