### PR TITLE
Python 3.11, and per-platform specifying of whether to do a conda build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,25 +37,29 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: ubuntu-latest,   python: '3.10',  arch: x64 }
-          - { os: ubuntu-latest,   python: '3.9',  arch: x64 }
-          - { os: ubuntu-latest,   python: '3.8',  arch: x64 }
-          - { os: ubuntu-latest,   python: '3.7',  arch: x64 }
+          - { os: ubuntu-latest,   python: '3.11',  arch: x64, conda: true}
+          - { os: ubuntu-latest,   python: '3.10',  arch: x64, conda: true }
+          - { os: ubuntu-latest,   python: '3.9',  arch: x64, conda: true }
+          - { os: ubuntu-latest,   python: '3.8',  arch: x64, conda: true }
+          - { os: ubuntu-latest,   python: '3.7',  arch: x64, conda: true }
 
-          - { os: macos-11,    python: '3.10',  arch: x64 }
-          - { os: macos-11,    python: '3.9',  arch: x64 }
-          - { os: macos-11,    python: '3.8',  arch: x64 }
-          - { os: macos-11,    python: '3.7',  arch: x64 }
+          - { os: macos-11,    python: '3.11',  arch: x64, conda: true }
+          - { os: macos-11,    python: '3.10',  arch: x64, conda: true }
+          - { os: macos-11,    python: '3.9',  arch: x64, conda: true }
+          - { os: macos-11,    python: '3.8',  arch: x64, conda: true }
+          - { os: macos-11,    python: '3.7',  arch: x64, conda: true }
 
-          - { os: windows-latest,  python: '3.10',  arch: x64 }
-          - { os: windows-latest,  python: '3.9',  arch: x64 }
-          - { os: windows-latest,  python: '3.8',  arch: x64 }
-          - { os: windows-latest,  python: '3.7',  arch: x64 }
+          - { os: windows-latest,  python: '3.11',  arch: x64, conda: true }
+          - { os: windows-latest,  python: '3.10',  arch: x64, conda: true }
+          - { os: windows-latest,  python: '3.9',  arch: x64, conda: true }
+          - { os: windows-latest,  python: '3.8',  arch: x64, conda: true }
+          - { os: windows-latest,  python: '3.7',  arch: x64, conda: true }
 
-          - { os: windows-latest,  python: '3.10',  arch: x86 }
-          - { os: windows-latest,  python: '3.9',  arch: x86 }
-          - { os: windows-latest,  python: '3.8',  arch: x86 }
-          - { os: windows-latest,  python: '3.7',  arch: x86 }
+          - { os: windows-latest,  python: '3.11',  arch: x86, conda: false } # conda not yet available
+          - { os: windows-latest,  python: '3.10',  arch: x86, conda: true }
+          - { os: windows-latest,  python: '3.9',  arch: x86, conda: true }
+          - { os: windows-latest,  python: '3.8',  arch: x86, conda: true }
+          - { os: windows-latest,  python: '3.7',  arch: x86, conda: true }
 
     if: github.repository == 'rpanderson/workflow-sandbox' && (github.event_name != 'create' || github.event.ref_type != 'branch')
     steps:
@@ -95,6 +99,7 @@ jobs:
           path: ./dist
 
       - name: Set Variables for Conda Build
+        if: matrix.conda
         shell: bash
         run: |
           if [ $NOARCH == true ]; then
@@ -105,6 +110,7 @@ jobs:
           echo "CONDA_BUILD_ARGS=$CONDA_BUILD_ARGS" >> $GITHUB_ENV
 
       - name: Install Miniconda
+        if: matrix.conda
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
@@ -119,20 +125,21 @@ jobs:
           xcode-version: 11.7
 
       - name: Conda package (Unix)
-        if: runner.os != 'Windows'
+        if: (matrix.conda && runner.os != 'Windows')
         shell: bash -l {0}
         run: |
           conda install -c labscript-suite setuptools-conda
           setuptools-conda build $CONDA_BUILD_ARGS .
 
       - name: Conda Package (Windows)
-        if: runner.os == 'Windows'
+        if: (matrix.conda && runner.os == 'Windows')
         shell: cmd /C CALL {0}
         run: |
           conda install -c labscript-suite setuptools-conda && ^
           setuptools-conda build %CONDA_BUILD_ARGS% --croot ${{ runner.temp }}\cb .
 
       - name: Upload Artifact
+        if: matrix.conda
         uses: actions/upload-artifact@v3
         with:
           name: conda_packages
@@ -158,7 +165,7 @@ jobs:
         if: env.PURE == 'false'
         uses: RalfG/python-wheels-manylinux-build@v0.4.2
         with:
-          python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310'
+          python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
           pre-build-command: 'git config --global --add safe.directory "*"'
 
       - name: Upload Artifact

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9    
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development :: Testing
     Topic :: Software Development :: Version Control :: Git
     Topic :: System :: Archiving :: Packaging


### PR DESCRIPTION
Add Python 3.11 to the build.

conda doesn't have Python 3.11 for 32-bit Windows yet. Rather than allow this to hold back all other platforms, add a mechanism to specify per-platform whether to build a conda package.

In the past, releases of conda, and in particular conda-build, have lagged months to over a year behind the rest of the Python ecosystem when a new version of Python is released. So far we have just allowed that to hold back all our releases, but with this change we can move ahead with the platforms that are supported, or release for PyPI only.