### PR TITLE
Use macos 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,10 @@ jobs:
           - { os: ubuntu-latest,   python: '3.8',  arch: x64 }
           - { os: ubuntu-latest,   python: '3.7',  arch: x64 }
 
-          - { os: macos-10.15,    python: '3.10',  arch: x64 }
-          - { os: macos-10.15,    python: '3.9',  arch: x64 }
-          - { os: macos-10.15,    python: '3.8',  arch: x64 }
-          - { os: macos-10.15,    python: '3.7',  arch: x64 }
+          - { os: macos-11,    python: '3.10',  arch: x64 }
+          - { os: macos-11,    python: '3.9',  arch: x64 }
+          - { os: macos-11,    python: '3.8',  arch: x64 }
+          - { os: macos-11,    python: '3.7',  arch: x64 }
 
           - { os: windows-latest,  python: '3.10',  arch: x64 }
           - { os: windows-latest,  python: '3.9',  arch: x64 }
@@ -112,7 +112,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           miniconda-version: "latest"
 
-      - name: Workaround conda-build incompatibility with xcode >12
+      - name: Workaround conda-build incompatibility with xcode 12+
         if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:


### PR DESCRIPTION
The GitHub macos 10.15 runner is being deprecated this year. And on macos-latest, we're unable to use xcode 11.7, at least not via the `maxim-lobanov/setup-xcode@v1` action:

```
Run maxim-lobanov/setup-xcode@v1
Switching Xcode to version '11.7'...
Available versions:
┌─────────┬──────────┬─────────────┬─────────────┬────────┬──────────────────────────────────┐
│ (index) │ version  │ buildNumber │ releaseType │ stable │               path               │
├─────────┼──────────┼─────────────┼─────────────┼────────┼──────────────────────────────────┤
│    0    │ '14.2.0' │   '14C18'   │    'GM'     │  true  │  '/Applications/Xcode_14.2.app'  │
│    1    │ '14.1.0' │  '14B47b'   │    'GM'     │  true  │  '/Applications/Xcode_14.1.app'  │
│    2    │ '14.0.1' │  '14A400'   │    'GM'     │  true  │ '/Applications/Xcode_14.0.1.app' │
│    3    │ '13.4.1' │  '13F100'   │    'GM'     │  true  │ '/Applications/Xcode_13.4.1.app' │
│    4    │ '13.3.1' │  '13E500a'  │    'GM'     │  true  │ '/Applications/Xcode_13.3.1.app' │
│    5    │ '13.2.1' │  '13C100'   │    'GM'     │  true  │ '/Applications/Xcode_13.2.1.app' │
│    6    │ '13.1.0' │ '13A1030d'  │    'GM'     │  true  │  '/Applications/Xcode_13.1.app'  │
└─────────┴──────────┴─────────────┴─────────────┴────────┴──────────────────────────────────┘
Error: Could not find Xcode version that satisfied version spec: '11.7'
```

Conda packages with C extensions won't build on xcode 12 or higher.

Hopefully by the time the macos 11 is deprecated, either conda works with newer xcode versions, or we finally figure out what the conda documentation is on about on [this page](https://docs.conda.io/projects/conda-build/en/latest/resources/compiler-tools.html), which I have never been able to make heads or tails of.