### PR TITLE
WIP: Update workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,16 @@ jobs:
           - { os: ubuntu-latest,   python: '3.8',  arch: x64, conda: true }
           - { os: ubuntu-latest,   python: '3.7',  arch: x64, conda: true }
 
-          - { os: macos-11,    python: '3.11',  arch: x64, conda: true }
-          - { os: macos-11,    python: '3.10',  arch: x64, conda: true }
-          - { os: macos-11,    python: '3.9',  arch: x64, conda: true }
-          - { os: macos-11,    python: '3.8',  arch: x64, conda: true }
-          - { os: macos-11,    python: '3.7',  arch: x64, conda: true }
+          - { os: macos-13,    python: '3.11',  arch: x64, conda: true }
+          - { os: macos-13,    python: '3.10',  arch: x64, conda: true }
+          - { os: macos-13,    python: '3.9',  arch: x64, conda: true }
+          - { os: macos-13,    python: '3.8',  arch: x64, conda: true }
+          - { os: macos-13,    python: '3.7',  arch: x64, conda: true }
+
+          - { os: macos-latest,    python: '3.11',  arch: arm64,  conda: true}
+          - { os: macos-latest,    python: '3.10',  arch: arm64,  conda: true}
+          - { os: macos-latest,    python: '3.9',  arch: arm64,  conda: true}
+          - { os: macos-latest,    python: '3.8',  arch: arm64,  conda: false}
 
           - { os: windows-latest,  python: '3.11',  arch: x64, conda: true }
           - { os: windows-latest,  python: '3.10',  arch: x64, conda: true }
@@ -122,7 +127,7 @@ jobs:
         if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 11.7
+          xcode-version: latest-stable
 
       - name: Conda package (Unix)
         if: (matrix.conda && runner.os != 'Windows')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - maintenance/*
-  create:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 
@@ -66,7 +65,7 @@ jobs:
           - { os: windows-latest,  python: '3.8',  arch: x86, conda: true }
           - { os: windows-latest,  python: '3.7',  arch: x86, conda: true }
 
-    if: github.repository == 'rpanderson/workflow-sandbox' && (github.event_name != 'create' || github.event.ref_type != 'branch')
+    if: github.repository == 'rpanderson/workflow-sandbox'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -74,7 +73,7 @@ jobs:
           fetch-depth: 0
 
       - name: Ignore Tags
-        if: github.event.ref_type != 'tag'
+        if: github.event.ref_type == 'push' && contains(github.ref, '/tags')
         run: git tag -d $(git tag --points-at HEAD)
 
       - name: Install Python
@@ -154,7 +153,7 @@ jobs:
   manylinux:
     name: Build Manylinux
     runs-on: ubuntu-latest
-    if: github.repository == 'rpanderson/workflow-sandbox' && (github.event_name != 'create' || github.event.ref_type != 'branch')
+    if: github.repository == 'rpanderson/workflow-sandbox'
     steps:
       - name: Checkout
         if: env.PURE == 'false'
@@ -163,7 +162,7 @@ jobs:
           fetch-depth: 0
 
       - name: Ignore Tags
-        if: github.event.ref_type != 'tag' && env.PURE == 'false'
+        if: contains(github.ref, '/tags') && env.PURE == 'false'
         run: git tag -d $(git tag --points-at HEAD)
 
       - name: Build Manylinux Wheels
@@ -201,13 +200,13 @@ jobs:
           merge-multiple: true
 
       - name: Get Version Number
-        if: github.event.ref_type == 'tag'
+        if: contains(github.ref, '/tags')
         run: |
           VERSION="${GITHUB_REF/refs\/tags\/v/}"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Create GitHub Release and Upload Release Asset
-        if: github.event.ref_type == 'tag'
+        if: contains(github.ref, '/tags')
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -226,7 +225,7 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish on PyPI
-        if: github.event.ref_type == 'tag'
+        if: contains(github.ref, '/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
@@ -242,7 +241,7 @@ jobs:
         run: conda install anaconda-client
 
       - name: Publish to Anaconda test label
-        if: github.event.ref_type != 'tag'
+        if: contains(github.ref, '/tags')
         shell: bash -l {0}
         run: |
           anaconda \
@@ -254,7 +253,7 @@ jobs:
 
       - name: Publish to Anaconda main label
         shell: bash -l {0}
-        if: github.event.ref_type == 'tag'
+        if: contains(github.ref, '/tags')
         run: |
           anaconda \
             --token ${{ secrets.ANACONDA_API_TOKEN }} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
     if: github.repository == 'rpanderson/workflow-sandbox' && (github.event_name != 'create' || github.event.ref_type != 'branch')
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -73,7 +73,7 @@ jobs:
         run: git tag -d $(git tag --points-at HEAD)
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           architecture: ${{ matrix.arch }}
@@ -111,7 +111,7 @@ jobs:
 
       - name: Install Miniconda
         if: matrix.conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python }}
@@ -153,7 +153,7 @@ jobs:
     steps:
       - name: Checkout
         if: env.PURE == 'false'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -226,7 +226,7 @@ jobs:
           password: ${{ secrets.pypi }}
 
       - name: Install Miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,9 +93,9 @@ jobs:
 
       - name: Upload Artifact
         if: strategy.job-index == 0 || (env.PURE == 'false' && runner.os != 'Linux')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-${{ matrix.os }}-py${{ matrix.python }}-${{ matrix.arch }}
           path: ./dist
 
       - name: Set Variables for Conda Build
@@ -140,9 +140,9 @@ jobs:
 
       - name: Upload Artifact
         if: matrix.conda
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: conda_packages
+          name: conda_packages-${{ matrix.os }}-py${{ matrix.python }}-${{ matrix.arch }}
           path: ./conda_packages
 
 
@@ -170,9 +170,9 @@ jobs:
 
       - name: Upload Artifact
         if: env.PURE == 'false'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-manylinux
           path: dist/*manylinux*.whl
 
   release:
@@ -182,16 +182,18 @@ jobs:
     steps:
 
       - name: Download Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: dist
+          pattern: dist*
           path: ./dist
+          merge-multiple: true
 
       - name: Download Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: conda_packages
+          pattern: conda_packages-*
           path: ./conda_packages
+          merge-multiple: true
 
       - name: Get Version Number
         if: github.event.ref_type == 'tag'


### PR DESCRIPTION
This PR has a few aims:

 - Update the workflow action pins, particularly to get ahead of the node.js==16 deprecation. Most are simple updates, but the `upload-artifact` action now requires that each upload have a unique name, so the workflow logic has to change slightly to accommodate.
- Update mac-os runners. `macos-11` is EOL, so bumping to `macos-13` for x64 builds and adding `macos-latest` for arm64 builds. This changes the xcode workaround for conda-build (as xcode-11 is no longer available). I haven't seen issues yet using latest on the newer runners, but some testing is warranted, especially with compiled extensions.
- Fix tag creation filtering. The `create` event does not allow [actual tag filtering](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#create). Currently it triggers if a branch or tag is created and silently ignores the request to filter. Actual tag filtering can only be done for `push` events (AFAIK), which requires modification to the logic throughout the workflow.

Plan for the PR is to implement progressively more invasive changes for easier review and testing.